### PR TITLE
Adding environment name to emails sent by offline service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,3 +247,4 @@ ModelManifest.xml
 .fake/
 /OfflineSubscriptionManager/App.Secrets.config
 /CogsMinimizer/App.Secrets.config
+/SubMinimizerTests/App.Secrets.config

--- a/CogsMinimizer/CogsMinimizer.csproj
+++ b/CogsMinimizer/CogsMinimizer.csproj
@@ -315,11 +315,9 @@
       <SubType>Designer</SubType>
     </Content>
     <Content Include="App.Secrets.config" />
-    <None Include="Properties\PublishProfiles\SubMinimizer - FTP.pubxml" />
-    <None Include="Properties\PublishProfiles\SubMinimizer - FTP1.pubxml" />
-    <None Include="Properties\PublishProfiles\subminimizer - Web Deploy.pubxml" />
     <Content Include="Properties\webjobs-list.json" />
-    <None Include="Properties\PublishProfiles\SubMinimizer - Web Deploy1.pubxml" />
+    <None Include="Properties\PublishProfiles\subminimizer - Web Deploy.pubxml" />
+    <None Include="Properties\PublishProfiles\SubMinimizerPPE - Web Deploy.pubxml" />
     <None Include="Scripts\jquery-1.10.2.intellisense.js" />
     <Content Include="Scripts\colResizable-1.6.js" />
     <Content Include="Scripts\jquery-1.10.2.js" />

--- a/OfflineSubscriptionManager/App.config
+++ b/OfflineSubscriptionManager/App.config
@@ -47,6 +47,8 @@
 
     <!--Telemetry settings-->
     <add key="TelemetryInstrumentationKey" value="5EB05D75-3D36-44F7-A005-C4EF7608833B" />
-    
+
+    <add key="ENV_DISPLAY_NAME" value="MAXIMSH-DEV" />
+
   </appSettings>
 </configuration>

--- a/OfflineSubscriptionManager/EmailUtils.cs
+++ b/OfflineSubscriptionManager/EmailUtils.cs
@@ -146,6 +146,8 @@ namespace OfflineSubscriptionManager
             Diagnostics.EnsureArgumentNotNull(() => tracer);
 
             string apiKey = ConfigurationManager.AppSettings["API_KEY"];
+            tracer.TraceInformation($"API_KEY length: {apiKey.Length}");
+
             dynamic sg = new SendGridAPIClient(apiKey);
 
             Email from = new Email("noreply@subminimizer.com");
@@ -167,12 +169,14 @@ namespace OfflineSubscriptionManager
                 mail.Personalization[0].Bccs = email.BCC.ToList();
             }
 
-            tracer.TraceInformation($"Sending email To: { string.Join(";", mail.Personalization[0].Tos)} Subject: {email.Subject} " +
-                                    $"Cc: { string.Join(";", email.CC)} " +
-                                    $"Bcc: { string.Join(";", email.BCC)}");
+            tracer.TraceInformation($"Sending email To: { string.Join(";", mail.Personalization[0].Tos.Select(item=>item.Address))} " +
+                $"Subject: {email.Subject} " +
+                $"Cc: { string.Join(";", email.CC.Select(item=> item.Address))} " +
+                                    $"Bcc: { string.Join(";", email.BCC.Select(item => item.Address))}");
 
             dynamic response = await sg.client.mail.send.post(requestBody: mail.Get());
             tracer.TraceInformation($"Email was sent for {email.Subject}");
+            tracer.TraceInformation($"SendGrid response: {response.StatusCode}");
         }
     }
 }

--- a/OfflineSubscriptionManager/Functions.cs
+++ b/OfflineSubscriptionManager/Functions.cs
@@ -61,7 +61,13 @@ namespace OfflineSubscriptionManager
         {
             //Email to = new Email("maximsh@microsoft.com");
             Subscription sub = analysisResult.AnalyzedSubscription;
-            string subject = $"SubMinimizer: Subscription Analysis report for {sub.DisplayName}";
+            string envDisplayName = ConfigurationManager.AppSettings["ENV_DISPLAY_NAME"];
+            if (! string.IsNullOrWhiteSpace(envDisplayName))
+            {
+                envDisplayName = $" [{envDisplayName}]";
+            }
+
+            string subject = $"SubMinimizer{envDisplayName}: Subscription Analysis report for {sub.DisplayName}";
 
             // Don't send mail if all resources are valid if subscription setting set appropriately
             if (sub.SendEmailOnlyInvalidResources)


### PR DESCRIPTION
Adding environment name to emails sent by offline service
Prod will not show anything as it is the default.
PPE will show [PPE]
Dev machines are required to add their own environment display name.