### PR TITLE
Scan upon registration

### DIFF
--- a/CogsMinimizer/CogsMinimizer.csproj
+++ b/CogsMinimizer/CogsMinimizer.csproj
@@ -138,9 +138,8 @@
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
@@ -374,6 +373,7 @@
     <Content Include="Views\Subscription\GetSettings.cshtml" />
     <Content Include="Views\Home\Error.cshtml" />
     <Content Include="Views\Subscription\Register.cshtml" />
+    <Content Include="Views\Home\Message.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />

--- a/CogsMinimizer/Controllers/HomeController.cs
+++ b/CogsMinimizer/Controllers/HomeController.cs
@@ -127,6 +127,14 @@ namespace CogsMinimizer.Controllers
             return View();
         }
 
+
+        public ActionResult Message(string message)
+        {
+            Diagnostics.EnsureStringNotNullOrWhiteSpace(() => message);
+            ViewData["Message"] = message;
+            return View();
+        }
+
         public ActionResult About()
         {
             return View();

--- a/CogsMinimizer/Views/Home/Index.cshtml
+++ b/CogsMinimizer/Views/Home/Index.cshtml
@@ -15,18 +15,6 @@
         $('.wait-crs').on('click', function () { $('body').css('cursor', 'wait'); $('.btn').css('cursor', 'wait'); })
     });
 
-    function CheckSubscriptionConnectDate(btn)
-    {
-        var href = $(btn).prop("href");
-        var connTimeHoursMatches = href.match(/ConnectedTime=([0-9]*)/);
-        var connTimeHours = connTimeHoursMatches[1]
-
-        if (connTimeHours <= 24)
-        {
-            alert("This subscription has not been analyzed yet. Please check back tomorrow. If the problem persists, then contact support.");
-        }
-    }
-
 </script>
 <div class="jumbotron">
     <h1>SubMinimizer</h1>
@@ -85,10 +73,9 @@
                                {
                                    Id = @subscription.Id,
                                    OrganizationId = @subscription.OrganizationId,
-                                   DisplayName = @subscription.DisplayName,
-                                   ConnectedTime = (DateTime.Now - @subscription.ConnectedOn).TotalHours
+                                   DisplayName = @subscription.DisplayName
                                },
-                               new { @class = "btn btn-success btn-xs wait-crs", onclick = "javascript: CheckSubscriptionConnectDate(this); return true;" })
+                               new { @class = "btn btn-success btn-xs wait-crs"})
 
                                 <small>&nbsp;&nbsp;</small>
 

--- a/CogsMinimizer/Views/Home/Message.cshtml
+++ b/CogsMinimizer/Views/Home/Message.cshtml
@@ -1,0 +1,11 @@
+﻿@{
+    ViewBag.Title = "Notice";
+}
+<h2>@ViewBag.Title</h2>
+
+<p class="lead">@ViewData["Message"]</p>
+
+<address>
+    <strong>Support:</strong>   <a href="mailto:maximsh@microsoft.com">maximsh@microsoft.com</a><br />
+</address>
+

--- a/CogsMinimizer/Web.config
+++ b/CogsMinimizer/Web.config
@@ -34,7 +34,7 @@
 
     <!-- Environment specific settings-->
     <add key="APPINSIGHTS_INSTRUMENTATIONKEY" value="00000000-0000-0000-0000-000000000000" />
-
+    
   </appSettings>
   <system.web>
     <authentication mode="None" />
@@ -76,7 +76,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />

--- a/CogsMinimizer/packages.config
+++ b/CogsMinimizer/packages.config
@@ -54,7 +54,7 @@
   <package id="Microsoft.Web.WebJobs.Publish" version="1.0.12" targetFramework="net452" />
   <package id="Modernizr" version="2.6.2" targetFramework="net452" />
   <package id="Moment.js" version="2.3.1" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
   <package id="Respond" version="1.2.0" targetFramework="net452" />
   <package id="System.Buffers" version="4.4.0" targetFramework="net452" />

--- a/OfflineSubscriptionManager/App.config
+++ b/OfflineSubscriptionManager/App.config
@@ -21,7 +21,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/OfflineSubscriptionManager/Functions.cs
+++ b/OfflineSubscriptionManager/Functions.cs
@@ -1,18 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Configuration;
-using System.Data.Entity.Core.Mapping;
-using System.Data.SqlClient;
 using System.IO;
-using System.Linq;
-using System.Net.Mail;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs;
-using System.Net;
 using CogsMinimizer.Shared;
-using SendGrid;
-using SendGrid.Helpers.Mail;
 
 namespace OfflineSubscriptionManager
 {
@@ -33,7 +23,7 @@ namespace OfflineSubscriptionManager
             if (ConfigurationManager.AppSettings["env:EnableWebJob"].Equals("True", StringComparison.OrdinalIgnoreCase))
             {
                 tracer.TraceInformation("EnableWebJob switch is Enabled.");
-                ProcessSubscriptions(tracer);
+                SubscriptionProcessor.ProcessSubscriptions(tracer);
             }
             else
             {
@@ -43,101 +33,7 @@ namespace OfflineSubscriptionManager
             tracer.Flush();
         }
 
-        /// <summary>
-        /// The main method triggered periodically. Analyzes each one of the registered subscriptions 
-        /// and reports to the customer
-        /// </summary>
-        private static void ProcessSubscriptions(ITracer tracer)
-        {
-            using (var db = new DataAccess())
-            {
-                tracer.TraceInformation("DB access created");
-
-                foreach (var sub in db.Subscriptions.ToList())
-                {
-                    //Analyze the subscription
-                    SubscriptionAnalyzer analyzer = new SubscriptionAnalyzer(db, sub, true, tracer);
-                    SubscriptionAnalysisResult analysisResult = analyzer.AnalyzeSubscription();
-                    sub.LastAnalysisDate = analysisResult.AnalysisStartTime.Date;
-                    
-                    //Persist analysis results to DB
-                    db.SaveChanges();
-
-                    if (ConfigurationManager.AppSettings["env:AllowWebJobEmail"].Equals("True", StringComparison.OrdinalIgnoreCase))
-                    {
-                        tracer.TraceInformation("AllowWebJobEmail switch is Enabled.");
-
-                        //Send email with the outcome of the analysis
-                        EmailSubscriptionAnalysisResult(analysisResult, tracer);
-                    }
-                    else
-                    {
-                        tracer.TraceWarning("AllowWebJobEmail switch is disabled. Skipping sending email.");
-                    }
-                }
-            }
-        }
-
-        private static void EmailSubscriptionAnalysisResult(SubscriptionAnalysisResult analysisResult, ITracer tracer)
-        {
-            Subscription sub = analysisResult.AnalyzedSubscription;
-            string envDisplayName = ConfigurationManager.AppSettings["env:EnvDisplayName"];
-            if (! string.IsNullOrWhiteSpace(envDisplayName))
-            {
-                envDisplayName = $" [{envDisplayName}]";
-            }
-
-            string subject = $"SubMinimizer{envDisplayName}: Subscription Analysis report for {sub.DisplayName}";
-
-            // Don't send mail if all resources are valid if subscription setting set appropriately
-            if (sub.SendEmailOnlyInvalidResources)
-            {
-                if (analysisResult.NotFoundResources.Count == 0 &&
-                    analysisResult.NearExpiredResources.Count == 0 &&
-                    analysisResult.DeletedResources.Count == 0 && 
-                    analysisResult.FailedDeleteResources.Count == 0 &&
-                    analysisResult.ExpiredResources.Count == 0)
-                {
-                    return;
-                }
-            }
-
-            var message = EmailUtils.CreateEmailMessage(analysisResult, sub);
-
-            var to = new List<Email>();
-            var cc = new List<Email>();
-            var bcc = new List<Email>();
-
-            //Add To recepients - the subscription admin and anyone with an expired resource 
-            to.Add(new Email(sub.ConnectedBy));
-
-            to.AddRange(analysisResult.ExpiredResources.Where(x=> ! string.IsNullOrWhiteSpace(x.Owner)).Select(x=> new Email(x.Owner)));
-
-            //Add CC recepients - the subscription coadmins if so selected by the admin in the settings
-            if (sub.SendEmailToCoadmins && analysisResult.Admins != null)
-            {
-                cc.AddRange(analysisResult.Admins.Select(x=>new Email(x)));         
-            }
-
-            //Add CC recepients - additional recipients if configured by the admin in the settings
-            if (!string.IsNullOrWhiteSpace(sub.AdditionalRecipients))
-            {
-                var additionalRecipients = EmailAddressUtils.splitEmailsString(sub.AdditionalRecipients);
-                cc.AddRange(additionalRecipients.Select(x=>new Email(x)));
-            }
-
-            //Add BCC recepients - dev team, as configured in the app config
-            string devTeam = ConfigurationManager.AppSettings["env:DevTeam"];
-            if (devTeam != null)
-            {
-                bcc.AddRange(devTeam.Split(';').Select(x => new Email(x)));
-            }
-
-            var email = new SubMinimizerEmail(subject, message, to, cc, bcc );
-
-            EmailUtils.SendEmail(email, tracer).Wait();
-        }
-
+       
      
 
 

--- a/OfflineSubscriptionManager/OfflineSubscriptionManager.csproj
+++ b/OfflineSubscriptionManager/OfflineSubscriptionManager.csproj
@@ -88,17 +88,8 @@
       <HintPath>..\packages\WindowsAzure.Storage.7.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="SendGrid, Version=8.0.2.0, Culture=neutral, PublicKeyToken=4f047e93159395ca, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sendgrid.8.0.2\lib\SendGrid.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="SendGrid.CSharp.HTTP.Client, Version=3.0.0.0, Culture=neutral, PublicKeyToken=79219bf4e5ecaaca, processorArchitecture=MSIL">
-      <HintPath>..\packages\SendGrid.CSharp.HTTP.Client.3.0.0\lib\SendGrid.CSharp.HTTP.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -125,15 +116,17 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="SubMinimizerEmail.cs" />
-    <Compile Include="EmailUtils.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Functions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
-    <None Include="packages.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Properties\PublishProfiles\subminimizer - Web Deploy.pubxml">
       <SubType>Designer</SubType>
     </None>

--- a/OfflineSubscriptionManager/packages.config
+++ b/OfflineSubscriptionManager/packages.config
@@ -10,9 +10,8 @@
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Web.WebJobs.Publish" version="1.0.12" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="Sendgrid" version="8.0.2" targetFramework="net45" />
-  <package id="SendGrid.CSharp.HTTP.Client" version="3.0.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.3.3" targetFramework="net452" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="7.0.0" targetFramework="net45" />
 </packages>

--- a/Shared/EmailUtils.cs
+++ b/Shared/EmailUtils.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Threading.Tasks;
+using SendGrid.Helpers.Mail;
+
+namespace CogsMinimizer.Shared
+{
+    class EmailUtils
+    {
+        internal static string CreateEmailMessage(SubscriptionAnalysisResult analysisResult, Subscription sub)
+        {
+            Diagnostics.EnsureArgumentNotNull(() => sub);
+            Diagnostics.EnsureArgumentNotNull(() => analysisResult);
+
+            string message = @"<!DOCTYPE html>
+                            <html lang=""en"">
+                            <head>    
+                                <meta content=""text/html; charset=utf-8"" http-equiv=""Content-Type"">
+                                <title>
+                                   Subminimizer report
+                                </title>
+                                <style type=""text/css"">
+                                    HTML{background-color: #ffffff;}
+                                    .courses-table{font-size: 16px; padding: 3px; border-collapse: collapse; border-spacing: 0;}
+                                    .courses-table .description{color: #505050;}
+                                    .courses-table td{border: 1px solid #D1D1D1; background-color: #F3F3F3; padding: 0 10px;}
+                                    .courses-table th{border: 1px solid #424242; color: #FFFFFF;text-align: left; padding: 0 10px;}
+                                    .tableheadercolor{background-color: #111111;}
+                                </style>
+                            </head>
+                            <body>";
+
+            string serviceURL = ConfigurationManager.AppSettings["env:ServiceURL"]; ;
+            string analyzeControllerLink = $"{serviceURL}/Subscription/Analyze/";
+            string headerLink = HTMLUtilities.CreateHTMLLink($"SubMinimizer report for subscription: {sub.DisplayName}",
+                $"{analyzeControllerLink}/{sub.Id}?OrganizationId={sub.OrganizationId}&DisplayName={sub.DisplayName}");
+
+            message += $"<H2>{headerLink}</H2>";
+
+            message += $"<H2>Subscription ID : {sub.Id} </H2>";
+            message += $"<H2>Analysis Date : {GetShortDate(sub.LastAnalysisDate)}</H2>";
+            message += "<br>";
+
+            if (analysisResult.DeletedResources.Count != 0)
+            {
+                message += $"<h3>Deleted {analysisResult.DeletedResources.Count} resource(s):</h3>";
+                message += GetHTMLTableForResources(analysisResult.DeletedResources);
+            }
+
+
+            if (analysisResult.FailedDeleteResources.Count != 0)
+            {
+                message += $"<h3>Failed deleting {analysisResult.FailedDeleteResources.Count} resource(s):</h3>";
+                message += GetHTMLTableForResources(analysisResult.FailedDeleteResources);
+            }
+
+            if (analysisResult.ExpiredResources.Count == 0)
+            {
+                message += "<h3>No expired resources found</h3>";
+            }
+            else
+            {
+                message += $"<h3>Found {analysisResult.ExpiredResources.Count} expired resource(s):</h3>";
+                if (sub.ManagementLevel == SubscriptionManagementLevel.AutomaticDelete ||
+                    sub.ManagementLevel == SubscriptionManagementLevel.ManualDelete)
+                {
+                    message +=
+                        "<h3><font color=\"#ff0000\"><b>WARNING - Expired resources are about to be deleted!</b></font></h3>" +
+                        $"<h3>Based on current settings, expired resources will be deleted after {sub.DeleteIntervalInDays} days </h3>";
+                }
+
+                message += GetHTMLTableForResources(analysisResult.ExpiredResources);
+            }
+
+            if (analysisResult.NotFoundResources.Count != 0)
+            {
+                message += $"<h3>Couldn't find {analysisResult.NotFoundResources.Count} resource(s):</h3>";
+                message += GetHTMLTableForResources(analysisResult.NotFoundResources);
+            }
+
+            if (analysisResult.NewResources.Count != 0)
+            {
+                message += $"<h3>Found {analysisResult.NewResources.Count} new resource(s) :</h3>";
+                message += GetHTMLTableForResources(analysisResult.NewResources);
+            }
+
+            if (analysisResult.ValidResources.Count != 0)
+            {
+                message += $"<h3>Found {analysisResult.ValidResources.Count} valid resource(s) :</h3>";
+                message += GetHTMLTableForResources(analysisResult.ValidResources);
+            }
+
+            message += "</body></html>";
+            return message;
+        }
+
+        private static string GetHTMLTableForResources(IEnumerable<Resource> resources)
+        {
+            resources = resources.OrderBy(x => x.ExpirationDate);
+
+            string result = "<Table class=\"courses-table\">";
+
+            result += "<tr>";
+            result += "<th class=\"tableheadercolor\">Name</th>";
+            result += "<th class=\"tableheadercolor\">Type</th>";
+            result += "<th class=\"tableheadercolor\">Group</th>";
+            result += "<th class=\"tableheadercolor\">Description</th>";
+            result += "<th class=\"tableheadercolor\">Owner</th>";
+            result += "<th class=\"tableheadercolor\">Expiration Date</th>";
+
+            result += "</tr>";
+
+            foreach (var resource in resources)
+            {
+                result += "<tr>";
+
+                result += $"<td><a href=\"https://ms.portal.azure.com/#resource{resource.AzureResourceIdentifier}\">{resource.Name}</a></td>";
+                //result += $"<td>{CreateHTMLLink(resource.Name, "https://ms.portal.azure.com/#resource\{resource.AzureResourceIdentifier}\\")}</td>";
+                result += $"<td>{resource.Type}</td>";
+                result += $"<td>{resource.ResourceGroup}</td>";
+                result += $"<td>{resource.Description}</td>";
+                string unclearOwner = !string.IsNullOrWhiteSpace(resource.Owner) && ! resource.ConfirmedOwner ? "(?)" : string.Empty;
+                result += $"<td>{resource.Owner} {unclearOwner}</td>";
+                result += $"<td>{GetShortDate(resource.ExpirationDate)}</td>";
+
+                result += "</tr>";
+            }
+            result += "</Table>";
+
+            return result;
+        }
+        private static string GetShortDate(DateTime dateTime)
+        {
+            return dateTime.ToString("dd-MMM-yy");
+        }
+
+
+        public static async Task SendEmail(SubMinimizerEmail email, ITracer tracer)
+        {
+            Diagnostics.EnsureArgumentNotNull(() => email);
+            Diagnostics.EnsureArgumentNotNull(() => tracer);
+
+            string apiKey = ConfigurationManager.AppSettings["API_KEY"];
+            tracer.TraceInformation($"API_KEY length: {apiKey.Length}");
+
+            dynamic sg = new SendGrid.SendGridAPIClient(apiKey);
+
+            Email from = new Email("noreply@subminimizer.com");
+
+            Content content = new Content("text/html", email.Content);
+
+            email.NormalizeAddresses();
+            
+            Mail mail = new Mail( from, email.Subject, email.To.First(), content);
+
+            mail.Personalization[0].Tos = email.To.ToList();
+            if (email.CC.Any())
+            {
+                mail.Personalization[0].Ccs = email.CC.ToList();
+            }
+
+            if (email.BCC.Any())
+            {
+                mail.Personalization[0].Bccs = email.BCC.ToList();
+            }
+
+            tracer.TraceInformation($"Sending email To: { string.Join(";", mail.Personalization[0].Tos.Select(item=>item.Address))} " +
+                $"Subject: {email.Subject} " +
+                $"Cc: { string.Join(";", email.CC.Select(item=> item.Address))} " +
+                                    $"Bcc: { string.Join(";", email.BCC.Select(item => item.Address))}");
+
+            dynamic response = await sg.client.mail.send.post(requestBody: mail.Get());
+            tracer.TraceInformation($"Email was sent for {email.Subject}");
+            tracer.TraceInformation($"SendGrid response: {response.StatusCode}");
+        }
+    }
+}

--- a/Shared/Shared.csproj
+++ b/Shared/Shared.csproj
@@ -69,17 +69,26 @@
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="SendGrid, Version=8.0.2.0, Culture=neutral, PublicKeyToken=4f047e93159395ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sendgrid.8.0.2\lib\SendGrid.dll</HintPath>
+    </Reference>
+    <Reference Include="SendGrid.CSharp.HTTP.Client, Version=3.0.0.0, Culture=neutral, PublicKeyToken=79219bf4e5ecaaca, processorArchitecture=MSIL">
+      <HintPath>..\packages\SendGrid.CSharp.HTTP.Client.3.0.0\lib\SendGrid.CSharp.HTTP.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
       <Private>True</Private>
@@ -113,6 +122,7 @@
     <Compile Include="AzureAuthUtils.cs" />
     <Compile Include="AzureDataUtils.cs" />
     <Compile Include="EmailAddressUtils.cs" />
+    <Compile Include="EmailUtils.cs" />
     <Compile Include="InMemoryTokenCache.cs" />
     <Compile Include="ResourceOperationsUtil.cs" />
     <Compile Include="AzureResourceManagerUtil.cs" />
@@ -137,11 +147,13 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resource.cs" />
     <Compile Include="ResourceStatus.cs" />
+    <Compile Include="SubMinimizerEmail.cs" />
     <Compile Include="Subscription.cs" />
     <Compile Include="SubscriptionAnalyzer.cs" />
     <Compile Include="SubscriptionAnalysisResult.cs" />
     <Compile Include="AzureResourceManagementRole.cs" />
     <Compile Include="SubscriptionManagementLevel.cs" />
+    <Compile Include="SubscriptionProcessor.cs" />
     <Compile Include="Tracing\AggregatedTracer.cs" />
     <Compile Include="Tracing\AITracer.cs" />
     <Compile Include="Tracing\ITracer.cs" />
@@ -149,6 +161,7 @@
     <Compile Include="Tracing\WebJobTracer.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/Shared/SubMinimizerEmail.cs
+++ b/Shared/SubMinimizerEmail.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO.IsolatedStorage;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SendGrid.Helpers.Mail;
+
+namespace CogsMinimizer.Shared
+{
+    class SubMinimizerEmail
+    {
+        public string Subject { get; set; }
+        public string Content { get; set; }
+        public IEnumerable<Email> To { get; private set; }
+        public IEnumerable<Email> CC { get; private set; }
+        public IEnumerable<Email> BCC { get; private set; }
+
+        public SubMinimizerEmail(string subject, string content, IEnumerable<Email> to, IEnumerable<Email> cc, IEnumerable<Email> bcc)
+        {
+            Subject = subject;
+            Content = content;
+            To = to;
+            CC = cc;
+            BCC = bcc;
+        }
+
+        /// <summary>
+        /// Makes sure every one of the addresses appears only once and in the highest level
+        /// To->Cc->Bcc
+        /// </summary>
+        public void NormalizeAddresses()
+        {
+            To = To.Select(x=>x.Address).Distinct().Select(x=> new Email(x));
+            var newCC= new List<Email>();
+            var newBCC = new List<Email>();
+
+            var handledEmails = To.Select(email => email.Address).ToList();
+
+            foreach (var email in CC)
+            {
+                if (!handledEmails.Contains(email.Address))
+                {
+                    newCC.Add(email);
+                    handledEmails.Add(email.Address);
+                }   
+            }
+
+            foreach (var email in BCC)
+            {
+                if (!handledEmails.Contains(email.Address))
+                {
+                    newBCC.Add(email);
+                    handledEmails.Add(email.Address);
+                }
+            }
+
+            CC = newCC;
+            BCC = newBCC;
+
+        }
+    }
+}

--- a/Shared/SubscriptionProcessor.cs
+++ b/Shared/SubscriptionProcessor.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using SendGrid;
+using SendGrid.Helpers.Mail;
+
+namespace CogsMinimizer.Shared
+{
+    public static class SubscriptionProcessor
+    {
+        /// <summary>
+        /// The main method triggered periodically. Analyzes each one of the registered subscriptions 
+        /// and reports to the customer
+        /// If a specific list of subscriptions is provided - only those will be processed. Needed to support the onboarding of a new subscription
+        /// </summary>
+        public static void ProcessSubscriptions(ITracer tracer, IEnumerable<string> subscriptionsToProcess=null)
+        {
+            using (var db = new DataAccess())
+            {
+                tracer.TraceInformation("DB access created");
+                var registeredSubscriptions = db.Subscriptions.ToList();
+
+                foreach (var sub in registeredSubscriptions)
+                {
+                    //if a white list of subscriptions was provided skip any that are not on the list
+                    if (subscriptionsToProcess != null && !subscriptionsToProcess.Contains(sub.Id)){
+                        continue;
+                    }
+
+                    //Analyze the subscription
+                    SubscriptionAnalyzer analyzer = new SubscriptionAnalyzer(db, sub, true, tracer);
+                    SubscriptionAnalysisResult analysisResult = analyzer.AnalyzeSubscription();
+                    sub.LastAnalysisDate = analysisResult.AnalysisStartTime;
+
+                    //Persist analysis results to DB
+                    db.SaveChanges();
+
+                    if (ConfigurationManager.AppSettings["env:AllowWebJobEmail"].Equals("True", StringComparison.OrdinalIgnoreCase))
+                    {
+                        tracer.TraceInformation("AllowWebJobEmail switch is Enabled.");
+
+                        //Send email with the outcome of the analysis
+                        EmailSubscriptionAnalysisResult(analysisResult, tracer);
+                    }
+                    else
+                    {
+                        tracer.TraceWarning("AllowWebJobEmail switch is disabled. Skipping sending email.");
+                    }
+                }
+            }
+        }
+
+        private static void EmailSubscriptionAnalysisResult(SubscriptionAnalysisResult analysisResult, ITracer tracer)
+        {
+            Subscription sub = analysisResult.AnalyzedSubscription;
+            string envDisplayName = ConfigurationManager.AppSettings["env:EnvDisplayName"];
+            if (!string.IsNullOrWhiteSpace(envDisplayName))
+            {
+                envDisplayName = $" [{envDisplayName}]";
+            }
+
+            string subject = $"SubMinimizer{envDisplayName}: Subscription Analysis report for {sub.DisplayName}";
+
+            // Don't send mail if all resources are valid if subscription setting set appropriately
+            if (sub.SendEmailOnlyInvalidResources)
+            {
+                if (analysisResult.NotFoundResources.Count == 0 &&
+                    analysisResult.NearExpiredResources.Count == 0 &&
+                    analysisResult.DeletedResources.Count == 0 &&
+                    analysisResult.FailedDeleteResources.Count == 0 &&
+                    analysisResult.ExpiredResources.Count == 0)
+                {
+                    return;
+                }
+            }
+
+            var message = EmailUtils.CreateEmailMessage(analysisResult, sub);
+
+            var to = new List<Email>();
+            var cc = new List<Email>();
+            var bcc = new List<Email>();
+
+            //Add To recepients - the subscription admin and anyone with an expired resource 
+            to.Add(new Email(sub.ConnectedBy));
+
+            to.AddRange(analysisResult.ExpiredResources.Where(x => !string.IsNullOrWhiteSpace(x.Owner)).Select(x => new Email(x.Owner)));
+
+            //Add CC recepients - the subscription coadmins if so selected by the admin in the settings
+            if (sub.SendEmailToCoadmins && analysisResult.Admins != null)
+            {
+                cc.AddRange(analysisResult.Admins.Select(x => new Email(x)));
+            }
+
+            //Add CC recepients - additional recipients if configured by the admin in the settings
+            if (!string.IsNullOrWhiteSpace(sub.AdditionalRecipients))
+            {
+                var additionalRecipients = EmailAddressUtils.splitEmailsString(sub.AdditionalRecipients);
+                cc.AddRange(additionalRecipients.Select(x => new Email(x)));
+            }
+
+            //Add BCC recepients - dev team, as configured in the app config
+            string devTeam = ConfigurationManager.AppSettings["env:DevTeam"];
+            if (devTeam != null)
+            {
+                bcc.AddRange(devTeam.Split(';').Select(x => new Email(x)));
+            }
+
+            var email = new SubMinimizerEmail(subject, message, to, cc, bcc);
+
+            EmailUtils.SendEmail(email, tracer).Wait();
+        }
+
+    }
+}

--- a/Shared/app.config
+++ b/Shared/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Shared/packages.config
+++ b/Shared/packages.config
@@ -3,11 +3,15 @@
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
   <package id="Microsoft.ApplicationInsights" version="2.2.0-beta2" targetFramework="net452" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net452" />
   <package id="Microsoft.Azure.Management.ResourceManager" version="1.3.1-preview" targetFramework="net452" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.27.306291202" targetFramework="net452" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.1.0" targetFramework="net452" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.1.0" targetFramework="net452" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net452" />
+  <package id="Sendgrid" version="8.0.2" targetFramework="net452" />
+  <package id="SendGrid.CSharp.HTTP.Client" version="3.0.0" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.3.3" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Streamlined the flow or registering a new subscription. It now triggers an immediate scan of that subscription. That was done by refactoring most of the offline subscription project into the shared project.
Updated Newtonsoft packages as well.